### PR TITLE
Allow newer crossterm and bump patch version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coolor"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 authors = ["dystroy <denys.seguret@gmail.com>"]
 repository = "https://github.com/Canop/coolor"
@@ -14,7 +14,7 @@ readme = "README.md"
 default = []
 
 [dependencies]
-crossterm = { optional=true, version="=0.23.2" }
+crossterm = { optional=true, version=">=0.23.2" }
 
 [dev-dependencies]
 rand = { version = "0.8", features = ["std_rng"] }


### PR DESCRIPTION
Please see [this MR](https://github.com/Canop/crokey/pull/17) for context.

These changes are to allow a newer version of `crossterm` to be used in `termimad` without causing a build error. It doesn't seem like this library is very tightly coupled with `crossterm`, so I simply allowed a newer version to be used and bumped the patch number of the library. If this seems insufficient, please let me know.